### PR TITLE
Identify clippings marked with an initial ^ as notes to a highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ command. It is recommended to import all generated Roam pages before
 doing a new export because books with new highlights will be overwritten.
 
 
+### Highlight Notes
+
+Kindle offers the feature of adding notes to a highlight. Unfortunately,
+they are not distinguishable from normal highlights in `My Clippings.txt`.
+To get around this, you can mark your notes with an initial `^` so `kindroam`
+recognizes them and attaches them as a sub-block. For example, if your note is
+`This highlight is important to me.`, it needs to be `^This highlight is
+important to me.` so it can become a sub-block.
+
+When Roam imports Markdown files, all the sub-blocks are collapsed. You can
+expand them all by right-clicking the page title and selecting `Expand All`.
+
+
 ## Installation
 
 To install the command-line tool, run:

--- a/src/kindroam/highlight.py
+++ b/src/kindroam/highlight.py
@@ -10,15 +10,20 @@ class Highlight(object):
                  book: str,
                  author: str,
                  content: str,
-                 added: datetime.datetime):
+                 added: datetime.datetime,
+                 note: str = ""):
 
         self.book = book
         self.author = author
         self.content = content
         self.added = added
+        self.note = note
 
     def to_block(self):
-        return f"- {self.content}\n"
+        block = f"- {self.content}\n"
+        if self.note != "":
+            block += f"\t- {self.note}\n"
+        return block
 
 
 def load_highlights(filename: str) -> List[Highlight]:
@@ -36,6 +41,7 @@ def parse_highlights(f: IO) -> List[Highlight]:
 
     assert len(lines) % 5 == 0
     highlights = []
+    highlight = None
 
     # Every 5 lines, there is a different highlight
     for i in range(0, len(lines), 5):
@@ -58,6 +64,12 @@ def parse_highlights(f: IO) -> List[Highlight]:
 
         # The content is in one line fortunately
         content = lines[i + 3].strip()
+
+        # A ^ at the beginning indicates to be a note that should be attached
+        # to the previous highlight.
+        if content.startswith("^") and highlight is not None:
+            highlight.note = content[1:]
+            continue
 
         highlight = Highlight(book, author, content, added)
         highlights.append(highlight)

--- a/src/kindroam/manager.py
+++ b/src/kindroam/manager.py
@@ -39,6 +39,8 @@ class Manager:
                 for c in highlights:
                     f.write(c.to_block())
 
+                print(f"Exported {len(highlights)} highlights of {book}.")
+
         self.db['last_updated'] = datetime.datetime.now()
         self._save_db()
         print(f"Exported {num_new_highlights} new highlights.")


### PR DESCRIPTION
`My Clippings.txt` does not distinguish between highlights and
notes of highlights. As a workaround, notes can be prepended
with a `^` and they will be recognized and exported as sub-blocks
in the resulting markdown.