### PR TITLE
Warn book overwrite

### DIFF
--- a/src/kindroam/manager.py
+++ b/src/kindroam/manager.py
@@ -31,11 +31,11 @@ class Manager:
 
         num_new_highlights = 0
         for book, highlights in highlights_by_book.items():
-            num_new_highlights += len(highlights)
 
             book_filename = os.path.join(books_dir, f"{book}.md")
             with open(book_filename, 'w') as f:
 
+                num_new_highlights += len(highlights)
                 for c in highlights:
                     f.write(c.to_block())
 

--- a/src/kindroam/manager.py
+++ b/src/kindroam/manager.py
@@ -33,6 +33,9 @@ class Manager:
         for book, highlights in highlights_by_book.items():
 
             book_filename = os.path.join(books_dir, f"{book}.md")
+            if os.path.isfile(book_filename):
+                self._warn_book_exists(book)
+
             with open(book_filename, 'w') as f:
 
                 num_new_highlights += len(highlights)
@@ -44,6 +47,13 @@ class Manager:
         self.db['last_updated'] = datetime.datetime.now()
         self._save_db()
         print(f"Exported {num_new_highlights} new highlights.")
+
+    def _warn_book_exists(self, book: str):
+        prompt = f"'{book}' has new highlights but the file already exists. "
+        prompt += "Make sure it has alaready been imported into Roam before "
+        prompt += "proceeding. This action will overwrite the existing file.\n"
+        prompt += "\n> Press Enter to continue\n"
+        input(prompt)
 
     def _load_db(self) -> None:
 

--- a/src/kindroam/manager.py
+++ b/src/kindroam/manager.py
@@ -30,6 +30,7 @@ class Manager:
         highlights_by_book = group_by_book(filtered_hls)
 
         num_new_highlights = 0
+        exported_prints = []
         for book, highlights in highlights_by_book.items():
 
             book_filename = os.path.join(books_dir, f"{book}.md")
@@ -42,7 +43,11 @@ class Manager:
                 for c in highlights:
                     f.write(c.to_block())
 
-                print(f"Exported {len(highlights)} highlights of {book}.")
+                exported_prints.append(
+                    f"Exported {len(highlights)} highlights of {book}.")
+
+        for p in exported_prints:
+            print(p)
 
         self.db['last_updated'] = datetime.datetime.now()
         self._save_db()


### PR DESCRIPTION
Generated book files will remain the unless the user deletes them.
Since Roam appends blocks when importing Markdown files, it is
better to only write new highlights to files. For this reason,
prompt the user whether the file should be overwritten or not.

For now, this will advance the last updated time regardless if
it is overwritten or not, so new highlights will be lost if they
are not accepted.