### PR TITLE
Create class DB to handle state and add ignore_warnings flag

### DIFF
--- a/src/kindroam/cli.py
+++ b/src/kindroam/cli.py
@@ -35,7 +35,7 @@ def cli():
 
 @cli.command()
 @click.option('--books-dir',
-              default='books',
+              default=KINDROAM_BOOK_DIR,
               help="Directory where the Roam Pages are saved.")
 def clean(books_dir):
     """Delete all Markdown files (.md) from the books directory."""

--- a/src/kindroam/cli.py
+++ b/src/kindroam/cli.py
@@ -52,7 +52,10 @@ def clean(books_dir):
 @click.option('--books-dir',
               default=KINDROAM_BOOK_DIR,
               help="Directory where the Roam Pages are saved.")
-def export(filename, books_dir):
+@click.option('--ignore-warnings',
+              is_flag=True,
+              help="Ignore overwrite warnings.")
+def export(filename, books_dir, ignore_warnings):
     """Load highlights from a `My Clippings.txt` file and export them
     as Roam pages to the books directory.
 
@@ -73,7 +76,7 @@ def export(filename, books_dir):
 
     manager = Manager(KINDROAM_DB_FILENAME, books_dir)
     highlights = load_highlights(filename)
-    manager.sync_highlights(highlights)
+    manager.sync_highlights(highlights, ignore_warnings)
 
 
 if __name__ == '__main__':

--- a/src/kindroam/manager.py
+++ b/src/kindroam/manager.py
@@ -50,7 +50,9 @@ class Manager:
     def __init__(self, db_filename: str, books_dir: str = 'books') -> None:
         self.db = DB.load(db_filename, books_dir)
 
-    def sync_highlights(self, highlights: List[HighlightType]) -> None:
+    def sync_highlights(self,
+                        highlights: List[HighlightType],
+                        ignore_warnings: bool) -> None:
         if not highlights:
             print("No highlights to sync.")
             return
@@ -66,7 +68,7 @@ class Manager:
         for book, highlights in highlights_by_book.items():
 
             book_filename = os.path.join(self.db.books_dir, f"{book}.md")
-            if os.path.isfile(book_filename):
+            if os.path.isfile(book_filename) and not ignore_warnings:
                 self._warn_book_exists(book)
 
             with open(book_filename, 'w') as f:


### PR DESCRIPTION
* There was a type hint missing in the Manager constructor and
this brought a lot of errors from `mypy`. It was easier to create
a class DB to handle the types of `books_dir` and `last_updated`.

* Add ignore_warnings flag so the overwrite prompt is skipped 