### PR TITLE
Change the sub-block character to be '+'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ doing a new export because books with new highlights will be overwritten.
 
 Kindle offers the feature of adding notes to a highlight. Unfortunately,
 they are not distinguishable from normal highlights in `My Clippings.txt`.
-To get around this, you can mark your notes with an initial `^` so `kindroam`
+To get around this, you can mark your notes with an initial `+` so `kindroam`
 recognizes them and attaches them as a sub-block. For example, if your note is
-`This highlight is important to me.`, it needs to be `^This highlight is
+`This highlight is important to me.`, it needs to be `+This highlight is
 important to me.` so it can become a sub-block.
 
 When Roam imports Markdown files, all the sub-blocks are collapsed. You can

--- a/src/kindroam/highlight.py
+++ b/src/kindroam/highlight.py
@@ -65,9 +65,9 @@ def parse_highlights(f: IO) -> List[Highlight]:
         # The content is in one line fortunately
         content = lines[i + 3].strip()
 
-        # A ^ at the beginning indicates to be a note that should be attached
+        # A + at the beginning indicates to be a note that should be attached
         # to the previous highlight.
-        if content.startswith("^") and highlight is not None:
+        if content.startswith("+") and highlight is not None:
             highlight.note = content[1:]
             continue
 


### PR DESCRIPTION
The `^` char is two clicks away from the kindle keyboard so
using `+` is much faster.